### PR TITLE
#9 JWT 발급 유틸리티 추가 및 로그인시 AccessToken 반환

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0")
+    implementation("io.jsonwebtoken:jjwt:0.12.5")
 
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/GamenomeProjectServerApplication.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/GamenomeProjectServerApplication.kt
@@ -1,9 +1,12 @@
 package sparta.nbcamp.gamenomeprojectserver
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.runApplication
+import sparta.nbcamp.gamenomeprojectserver.domain.security.jwt.JwtProperties
 
 @SpringBootApplication
+@EnableConfigurationProperties(JwtProperties::class)
 class GamenomeProjectServerApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/comment/dto/v1/CreateCommentRequestDto.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/comment/dto/v1/CreateCommentRequestDto.kt
@@ -14,8 +14,7 @@ data class CreateCommentRequestDto(
             return Comment(
                 user = user,
                 review = review,
-                content = createCommentRequestDto.content,
-                createdAt = LocalDateTime.now(),
+                content = createCommentRequestDto.content
             )
         }
     }

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/security/jwt/JwtPlugin.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/security/jwt/JwtPlugin.kt
@@ -1,0 +1,46 @@
+package sparta.nbcamp.gamenomeprojectserver.domain.security.jwt
+
+import io.jsonwebtoken.Claims
+import io.jsonwebtoken.Jws
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.security.Keys
+import org.springframework.stereotype.Component
+import java.nio.charset.StandardCharsets
+import java.time.Duration
+import java.time.Instant
+import java.util.*
+
+@Component
+class JwtPlugin(
+    private val jwtProperties: JwtProperties
+) {
+
+    fun validateToken(token: String): Result<Jws<Claims>> {
+        return kotlin.runCatching {
+            val key = Keys.hmacShaKeyFor(jwtProperties.secret.toByteArray(StandardCharsets.UTF_8))
+            Jwts.parser().verifyWith(key).build().parseSignedClaims(token)
+        }
+    }
+
+    fun generateAccessToken(subject: String, userId: Long) : String {
+        return generateToken(subject, userId, Duration.ofHours(jwtProperties.expirationHours))
+    }
+
+    private fun generateToken(subject: String, userId: Long, expirationPeriod: Duration?): String {
+        val claims = Jwts.claims()
+            .add("userId", userId)
+            .build()
+
+        val key = Keys.hmacShaKeyFor(jwtProperties.secret.toByteArray(StandardCharsets.UTF_8))
+        val now = Instant.now()
+
+        return Jwts.builder()
+            .subject(subject)
+            .issuer(jwtProperties.issuer)
+            .issuedAt(Date.from(now))
+            .expiration(Date.from(now.plus(expirationPeriod)))
+            .claims(claims)
+            .signWith(key)
+            .compact()
+    }
+}

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/security/jwt/JwtProperties.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/security/jwt/JwtProperties.kt
@@ -1,0 +1,12 @@
+package sparta.nbcamp.gamenomeprojectserver.domain.security.jwt
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@ConfigurationProperties(prefix = "jwt")
+class JwtProperties {
+    lateinit var secret: String
+    val issuer = "sparta.nbcamp.gamenomeprojectserver"
+    val expirationHours: Long = 168
+}

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/security/jwt/JwtResponseDto.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/security/jwt/JwtResponseDto.kt
@@ -1,0 +1,3 @@
+package sparta.nbcamp.gamenomeprojectserver.domain.security.jwt
+
+data class JwtResponseDto(val accessToken: String)

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/controller/v1/UserController.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/controller/v1/UserController.kt
@@ -3,9 +3,10 @@ package sparta.nbcamp.gamenomeprojectserver.domain.user.controller.v1
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
+import sparta.nbcamp.gamenomeprojectserver.domain.security.jwt.JwtResponseDto
 import sparta.nbcamp.gamenomeprojectserver.domain.user.dto.SignInDto
-import sparta.nbcamp.gamenomeprojectserver.domain.user.dto.UserDto
 import sparta.nbcamp.gamenomeprojectserver.domain.user.dto.SignUpDto
+import sparta.nbcamp.gamenomeprojectserver.domain.user.dto.UserDto
 import sparta.nbcamp.gamenomeprojectserver.domain.user.dto.UserUpdateProfileDto
 import sparta.nbcamp.gamenomeprojectserver.domain.user.service.v1.UserService
 
@@ -20,7 +21,7 @@ class UserController(
     }
 
     @PostMapping("/signin")
-    fun signIn(@RequestBody request: SignInDto): ResponseEntity<UserDto> {
+    fun signIn(@RequestBody request: SignInDto): ResponseEntity<JwtResponseDto> {
         return ResponseEntity.status(HttpStatus.OK).body(userService.signIn(request))
     }
 

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/service/v1/UserService.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/service/v1/UserService.kt
@@ -1,5 +1,6 @@
 package sparta.nbcamp.gamenomeprojectserver.domain.user.service.v1
 
+import sparta.nbcamp.gamenomeprojectserver.domain.security.jwt.JwtResponseDto
 import sparta.nbcamp.gamenomeprojectserver.domain.user.dto.SignInDto
 import sparta.nbcamp.gamenomeprojectserver.domain.user.dto.SignUpDto
 import sparta.nbcamp.gamenomeprojectserver.domain.user.dto.UserDto
@@ -7,7 +8,7 @@ import sparta.nbcamp.gamenomeprojectserver.domain.user.dto.UserUpdateProfileDto
 
 interface UserService {
     fun signUp(request: SignUpDto): UserDto
-    fun signIn(request: SignInDto): UserDto
+    fun signIn(request: SignInDto): JwtResponseDto
     fun getUserProfile(userId: Long): UserDto
     fun getUserProfileList(userIds: List<Long>): List<UserDto>
     fun updateProfile(userId: Long, request: UserUpdateProfileDto): UserDto

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/service/v1/UserService.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/service/v1/UserService.kt
@@ -13,4 +13,6 @@ interface UserService {
     fun getUserProfileList(userIds: List<Long>): List<UserDto>
     fun updateProfile(userId: Long, request: UserUpdateProfileDto): UserDto
     fun deactivateUser(userId: Long)
+    fun isValidToken(token: String): Boolean
+    fun getUserIdFromToken(token: String): Long
 }

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/service/v1/UserServiceImpl.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/service/v1/UserServiceImpl.kt
@@ -3,6 +3,8 @@ package sparta.nbcamp.gamenomeprojectserver.domain.user.service.v1
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import sparta.nbcamp.gamenomeprojectserver.domain.security.jwt.JwtPlugin
+import sparta.nbcamp.gamenomeprojectserver.domain.security.jwt.JwtResponseDto
 import sparta.nbcamp.gamenomeprojectserver.domain.user.dto.SignInDto
 import sparta.nbcamp.gamenomeprojectserver.domain.user.dto.SignUpDto
 import sparta.nbcamp.gamenomeprojectserver.domain.user.dto.UserDto
@@ -13,7 +15,8 @@ import sparta.nbcamp.gamenomeprojectserver.exception.ModelNotFoundException
 
 @Service
 class UserServiceImpl(
-    val userRepository: UserRepository
+    val userRepository: UserRepository,
+    val jwtPlugin: JwtPlugin
 ) : UserService {
 
     @Transactional
@@ -28,15 +31,17 @@ class UserServiceImpl(
     }
 
     @Transactional
-    override fun signIn(request: SignInDto): UserDto {
+    override fun signIn(request: SignInDto): JwtResponseDto {
         val user = userRepository.findByEmail(request.email)
             ?: throw IllegalStateException("User not found with email")
 
         // TODO: 패스워드 체크
 
+        val accessToken = jwtPlugin.generateAccessToken("userId", user.id ?: throw RuntimeException("User id is invalid"))
+
         user.signIn()
 
-        return UserDto.fromEntity(user)
+        return JwtResponseDto(accessToken)
     }
 
     override fun getUserProfile(userId: Long): UserDto {

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/service/v1/UserServiceImpl.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/service/v1/UserServiceImpl.kt
@@ -70,4 +70,12 @@ class UserServiceImpl(
 
         userRepository.delete(user)
     }
+
+    override fun isValidToken(token: String): Boolean {
+        return jwtPlugin.validateToken(token).isSuccess
+    }
+
+    override fun getUserIdFromToken(token: String): Long {
+        return jwtPlugin.validateToken(token).getOrNull()?.payload?.get("userId") as? Long ?: throw RuntimeException("User id is invalid")
+    }
 }


### PR DESCRIPTION


현재 1번 유저 email: test@test.com, password: 1234 로 테스트해볼 수 있습니다.

발급받은 AccessToken은 인증 정보가 필요한 곳에서 @RequestHeader("Authorization") token: String 로 **Header**에 포함된 인증 정보를 불러와서 Service로 넘기면 됩니다.

Service는 val jwtPlugin: JwtPlugin 을 주입 받아서 Controller 에서 받아온 토큰으로 validate에 사용하면 됩니다. generateAccessToken은 signIn에서만 사용하는 걸 추천드립니다.


몇가지 같이 알아본 사실로는
1. Controller 에서는 클라이언트의 요청만 처리하기 때문에 JwtPlugin 을 주입받지 않는 편이 좋다고 합니다. 최대한 Service 에서만 주입 받아주세요

2. 토큰 검증 / 토큰에서 userId 를 불러올 때는 user service에 미리 만들어둔 isValidToken, getUserIdFromToken 을 사용하면 더 좋을 것 같습니다.