### PR TITLE
#30 각 도메인의 유효성 / 불변성 검증 추가

### DIFF
--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/comment/dto/v1/CommentContentValidatableDto.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/comment/dto/v1/CommentContentValidatableDto.kt
@@ -1,0 +1,10 @@
+package sparta.nbcamp.gamenomeprojectserver.domain.comment.dto.v1
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+abstract class CommentContentValidatableDto(
+    @field:NotBlank
+    @field:Size(max = 200, message = "Content must be 200 characters or less")
+    open val content: String
+)

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/comment/dto/v1/CreateCommentRequestDto.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/comment/dto/v1/CreateCommentRequestDto.kt
@@ -6,16 +6,7 @@ import sparta.nbcamp.gamenomeprojectserver.domain.user.model.User
 import java.time.LocalDateTime
 
 data class CreateCommentRequestDto(
-    val content: String,
+    override val content: String,
+
     val stars: Double,
-){
-    companion object{
-        fun create(createCommentRequestDto: CreateCommentRequestDto, review : Review, user: User): Comment {
-            return Comment(
-                user = user,
-                review = review,
-                content = createCommentRequestDto.content
-            )
-        }
-    }
-}
+): CommentContentValidatableDto(content)

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/comment/dto/v1/ReportCommentRequestDto.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/comment/dto/v1/ReportCommentRequestDto.kt
@@ -1,8 +1,12 @@
 package sparta.nbcamp.gamenomeprojectserver.domain.comment.dto.v1
 
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
 import org.springframework.context.annotation.Description
 
 data class ReportCommentRequestDto(
+    @field:NotBlank
+    @field:Size(max = 200, message = "Description must be 200 characters or less")
     val description: String,
     val entityType: String = "Comment",
 )

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/comment/dto/v1/UpdateCommentRequestDto.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/comment/dto/v1/UpdateCommentRequestDto.kt
@@ -1,5 +1,5 @@
 package sparta.nbcamp.gamenomeprojectserver.domain.comment.dto.v1
 
 data class UpdateCommentRequestDto(
-    val content: String,
-)
+    override val content: String,
+) : CommentContentValidatableDto(content)

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/comment/entity/v1/Comment.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/comment/entity/v1/Comment.kt
@@ -3,13 +3,14 @@ package sparta.nbcamp.gamenomeprojectserver.domain.comment.entity.v1
 import jakarta.persistence.*
 import org.hibernate.annotations.CreationTimestamp
 import org.hibernate.annotations.UpdateTimestamp
+import sparta.nbcamp.gamenomeprojectserver.domain.comment.dto.v1.CreateCommentRequestDto
 import sparta.nbcamp.gamenomeprojectserver.domain.review.model.v1.Review
 import sparta.nbcamp.gamenomeprojectserver.domain.user.model.User
 import java.time.LocalDateTime
 
 @Entity
 @Table(name = "comment")
-class Comment(
+class Comment private constructor(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     val user: User,
@@ -41,5 +42,22 @@ class Comment(
 
     fun update(comment: String) {
         this.content = comment
+
+        this.validate()
+    }
+
+    private fun validate() {
+        require(this.content.isNotBlank()) { "Content must not be blank" }
+        require(this.content.length <= 100) { "Content must be 100 characters or less" }
+    }
+
+    companion object{
+        fun fromDto(createCommentRequestDto: CreateCommentRequestDto, review : Review, user: User): Comment {
+            return Comment(
+                user = user,
+                review = review,
+                content = createCommentRequestDto.content
+            ).apply { this.validate() }
+        }
     }
 }

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/comment/service/v1/CommentService.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/comment/service/v1/CommentService.kt
@@ -23,7 +23,7 @@ class CommentService(
         //TODO("유저 로그인 검증 및 블랙 리스트 검증")
         val reviewResult = reviewRepository.findByIdOrNull(reviewId)?: throw ModelNotFoundException("review", reviewId )
 
-        val result = CreateCommentRequestDto.create(createCommentRequestDto, reviewResult, userService.TODO())
+        val result = Comment.fromDto(createCommentRequestDto, reviewResult, userService.TODO())
 
         return CommentResponseDto.from(result)
 

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/report/dto/v1/ReportReviewDto.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/report/dto/v1/ReportReviewDto.kt
@@ -1,5 +1,10 @@
 package sparta.nbcamp.gamenomeprojectserver.domain.report.dto.v1
 
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
 data class ReportReviewDto(
+    @field:NotBlank
+    @field:Size(max = 200, message = "Content must be 200 characters or less")
     val description: String
 )

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/review/dto/v1/ReviewCreateDto.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/review/dto/v1/ReviewCreateDto.kt
@@ -1,7 +1,7 @@
 package sparta.nbcamp.gamenomeprojectserver.domain.review.dto.v1
 
 data class ReviewCreateDto(
-    val gameName: String,
-    val title: String,
-    val description: String,
-)
+    override val gameName: String,
+    override val title: String,
+    override val description: String,
+) : ReviewValidatableDto(gameName, title, description)

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/review/dto/v1/ReviewReportDto.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/review/dto/v1/ReviewReportDto.kt
@@ -1,6 +1,11 @@
 package sparta.nbcamp.gamenomeprojectserver.domain.review.dto.v1
 
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
 data class ReviewReportDto(
     val userId: Long,
+    @field:NotBlank
+    @field:Size(max = 200, message = "Description must be 200 characters or less")
     val description: String
 )

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/review/dto/v1/ReviewUpdateDto.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/review/dto/v1/ReviewUpdateDto.kt
@@ -1,7 +1,7 @@
 package sparta.nbcamp.gamenomeprojectserver.domain.review.dto.v1
 
 data class ReviewUpdateDto(
-    val gameName: String,
-    val title: String,
-    val description: String,
-)
+    override val gameName: String,
+    override val title: String,
+    override val description: String,
+) : ReviewValidatableDto(gameName, title, description)

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/review/dto/v1/ReviewValidatableDto.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/review/dto/v1/ReviewValidatableDto.kt
@@ -1,0 +1,18 @@
+package sparta.nbcamp.gamenomeprojectserver.domain.review.dto.v1
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+abstract class ReviewValidatableDto(
+    @field:NotBlank
+    @field:Size(max = 100, message = "Game name must be 100 characters or less")
+    open val gameName: String,
+
+    @field:NotBlank
+    @field:Size(max = 200, message = "Title must be 200 characters or less")
+    open val title: String,
+
+    @field:NotBlank
+    @field:Size(max = 2000, message = "Description must be 2000 characters or less")
+    open val description: String,
+)

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/review/model/v1/Review.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/review/model/v1/Review.kt
@@ -9,7 +9,7 @@ import java.time.LocalDateTime
 
 @Entity
 @Table(name = "review")
-class Review(
+class Review private constructor(
     @Column(name = "game_name", columnDefinition = "text", nullable = false)
     var gameName: String,
 
@@ -41,6 +41,19 @@ class Review(
         gameName = reviewUpdateDto.gameName
         title = reviewUpdateDto.title
         description = reviewUpdateDto.description
+
+        this.validate()
+    }
+
+    private fun validate() {
+        require(gameName.isNotBlank()) { "Game name cannot be blank" }
+        require(gameName.length <= 100) { "Game name must be 100 characters or less" }
+
+        require(title.isNotBlank()) { "Title cannot be blank" }
+        require(title.length <= 200) { "Title must be 200 characters or less" }
+
+        require(description.isNotBlank()) { "Description must not be blank" }
+        require(description.length <= 2000) { "Description must be 2000 characters or less" }
     }
 
     companion object {
@@ -49,7 +62,7 @@ class Review(
                 gameName = reviewCreateDto.gameName,
                 title = reviewCreateDto.title,
                 description = reviewCreateDto.description,
-            )
+            ).apply { this.validate() }
         }
     }
 }

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/controller/v1/UserController.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/controller/v1/UserController.kt
@@ -47,6 +47,7 @@ class UserController(
 
     @DeleteMapping("/users/deactivate")
     fun deactivateUser(): ResponseEntity<Unit> {
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).body(userService.deactivateUser(userId))
+        TODO()
+//        return ResponseEntity.status(HttpStatus.NO_CONTENT).body(userService.deactivateUser(userId))
     }
 }

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/dto/EmailPasswordValidatableDto.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/dto/EmailPasswordValidatableDto.kt
@@ -1,0 +1,14 @@
+package sparta.nbcamp.gamenomeprojectserver.domain.user.dto
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+abstract class EmailPasswordValidatableDto(
+    @field:NotBlank
+    @field:Size(max = 50, message = "Email must be 50 characters or less")
+    open val email: String,
+
+    @field:NotBlank
+    @field:Size(min = 8, max = 20, message = "Password must be between 8 and 20 characters")
+    open val password: String
+)

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/dto/SignInDto.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/dto/SignInDto.kt
@@ -1,6 +1,6 @@
 package sparta.nbcamp.gamenomeprojectserver.domain.user.dto
 
 data class SignInDto(
-    val email: String,
-    val password: String
-)
+    override val email: String,
+    override val password: String
+) : EmailPasswordValidatableDto(email, password)

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/dto/SignUpDto.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/dto/SignUpDto.kt
@@ -1,8 +1,17 @@
 package sparta.nbcamp.gamenomeprojectserver.domain.user.dto
 
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
 data class SignUpDto (
-    val email: String,
-    val password: String,
+    override val email: String,
+    override val password: String,
+
+    @field:NotBlank
+    @field:Size(min = 2, max = 20, message = "Nickname must be between 2 and 20 characters")
     val nickname: String,
+
+    @field:NotBlank
+    @field:Size(max = 50, message = "About summary must be 50 characters or less")
     val aboutSummary: String?,
-)
+) : EmailPasswordValidatableDto(email, password)

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/dto/UserUpdateProfileDto.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/dto/UserUpdateProfileDto.kt
@@ -1,9 +1,18 @@
 package sparta.nbcamp.gamenomeprojectserver.domain.user.dto
 
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
 data class UserUpdateProfileDto(
-    val email: String,
-    val password: String,
+    override val email: String,
+    override val password: String,
+
+    @field:NotBlank
+    @field:Size(min = 2, max = 20, message = "Nickname must be between 2 and 20 characters")
     val nickname: String,
+
+    @field:NotBlank
+    @field:Size(max = 50, message = "About summary must be 50 characters or less")
     val aboutSummary: String,
     val profileImageUrl: String?
-)
+) : EmailPasswordValidatableDto(email, password)

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/model/User.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/model/User.kt
@@ -9,7 +9,7 @@ import java.time.LocalDateTime
 
 @Entity
 @Table(name = "app_user")
-class User(
+class User private constructor(
     @Column(name = "email", length = 255, unique = true, nullable = false)
     var email: String,
 
@@ -46,6 +46,8 @@ class User(
             aboutSummary = request.aboutSummary,
             profileImageUrl = request.profileImageUrl
         )
+
+        this.validate()
     }
 
     fun checkUpdatePermission(user: User): Boolean {
@@ -54,6 +56,16 @@ class User(
 
     fun signIn() {
         this.lastSignInAt = LocalDateTime.now()
+    }
+
+    private fun validate() {
+        require(email.isNotBlank()) { "Email cannot be blank" }
+        require(email.length < 50) { "Email must be less than 50 characters" }
+
+        // 암호화 고려하여 password의 불변성 검증은 보류
+
+        require(profile.nickname.isNotBlank()) { "Nickname cannot be blank" }
+        require(profile.nickname.length in 2..20) { "Nickname must be between 2 and 20 characters" }
     }
 
     companion object {
@@ -65,7 +77,7 @@ class User(
                     nickname = request.nickname,
                     aboutSummary = request.aboutSummary,
                 )
-            )
+            ).apply { this.validate() }
         }
     }
 }


### PR DESCRIPTION


@field:{validation} 으로 Dto를 통해 Controller로 들어온 요청의 유효성 검증을 합니다.

Service 로직에서 유효성 처리를 하게 되면 좋지 않고 가급적 Controller에서 요청 들어오자마자 쳐낼 수 있는게 좋다고 생각합니다.


Entity는 이제 Private constructor고 fromDto를 통해서만 생성 가능합니다. 생성된 Entity는 즉시 apply { validate() }로 불변성 검증을 진행합니다.

그리고 Entity에 위임된 값 수정이 끝난 후에도 검증이 필요한 부분이 영향을 받았다면 불변성 검증을 진행합니다.