### PR TITLE
Feat: #13 패스워드 암호화 설정 및 Spring security 기본 로그인 disable 설정

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,8 @@ repositories {
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-security")
+
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0")

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/security/jwt/SecurityConfig.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/security/jwt/SecurityConfig.kt
@@ -1,0 +1,31 @@
+package sparta.nbcamp.gamenomeprojectserver.domain.security.jwt
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.security.web.SecurityFilterChain
+
+
+@Configuration
+class SecurityConfig {
+
+    @Bean
+    fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
+        http
+            .authorizeHttpRequests { requests ->
+                requests
+                    .anyRequest().permitAll()
+            }
+            .csrf { csrf -> csrf.disable() }
+            .formLogin { formLogin -> formLogin.disable() }
+
+        return http.build()
+    }
+
+    @Bean
+    fun passwordEncoder(): PasswordEncoder {
+        return BCryptPasswordEncoder()
+    }
+}


### PR DESCRIPTION

이제 SignUp 진행할 때 패스워드는 암호화 처리되고 SignIn 할 때도 암호화 기준으로 매칭이라 기존에 만든 유저는 작동하지 않습니다.

Spring security에서 기본적으로 제공하는 보안 로그인 페이지는 disable했습니다.