### PR TITLE
#57 Swagger header Authorization 추가

### DIFF
--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/controller/v1/UserController.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/controller/v1/UserController.kt
@@ -1,5 +1,6 @@
 package sparta.nbcamp.gamenomeprojectserver.domain.user.controller.v1
 
+import jakarta.servlet.http.HttpServletRequest
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
@@ -52,7 +53,10 @@ class UserController(
     }
 
     @GetMapping("/token/checkUserId")
-    fun checkUserId(@RequestParam token: String): ResponseEntity<Long> {
-        return ResponseEntity.status(HttpStatus.OK).body(userService.getUserIdFromToken(token))
+    fun checkUserId(
+        request: HttpServletRequest
+    ): ResponseEntity<Long> {
+        val authorization = request.getHeader("Authorization") ?: return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
+        return ResponseEntity.status(HttpStatus.OK).body(userService.getUserIdFromToken(authorization))
     }
 }

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/infra/swagger/SwaggerConfig.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/infra/swagger/SwaggerConfig.kt
@@ -1,21 +1,22 @@
 package sparta.nbcamp.gamenomeprojectserver.infra.swagger
 
-import io.swagger.v3.oas.models.info.Info
-import io.swagger.v3.oas.models.Components
-import io.swagger.v3.oas.models.OpenAPI
-import org.springframework.context.annotation.Bean
+import io.swagger.v3.oas.annotations.OpenAPIDefinition
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType
+import io.swagger.v3.oas.annotations.info.Info
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.security.SecurityScheme
 import org.springframework.context.annotation.Configuration
 
 @Configuration
-class SwaggerConfig {
-
-    @Bean
-    fun openAPI(): OpenAPI = OpenAPI()
-        .components(Components())
-        .info(
-            Info()
-                .title("Gamenome API")
-                .description("Gamenome API schema")
-                .version("1.0.0")
-        )
-}
+@OpenAPIDefinition(
+    info = Info(title = "Gamenome API", description = "Gamenome API schema", version = "1.0.0"),
+    security = [SecurityRequirement(name = "JWT")]
+)
+@SecurityScheme(
+    name = "JWT",
+    type = SecuritySchemeType.APIKEY,
+    `in` = SecuritySchemeIn.HEADER,
+    paramName = "Authorization"
+)
+class SwaggerConfig


### PR DESCRIPTION


Swagger 테스트에서 의도에 맞게 작동해야 해서 이렇게 했습니다.


@RequestHeader를 쓰면 각 API마다 필드가 하나 더 생기는데 정작 작동은 안해서 좀 의아하긴 한데 이제 우측 위에 Authorize 버튼을 눌러 발급받은 JWT로 인증하면 인증이 자동으로 Header에 포함되어 테스트됩니다.

HttpServletRequest 을 써서 header를 얻어오는 것과 @RequestHeader는 딱히 차이는 없다고 합니다. Swagger-ui에서 표기 되냐 마느냐의 차이밖에 없어서 좀 구리긴 해요

아직 저희끼리 Postman 에 대한 이야기는 나온 적 없으니 임시로 컨트롤러에서 HttpServletRequest 을 받아와서 `request.getHeader("Authorization") ?: return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()` 처럼 작성해주면 token 받아 쓸 수 있고

나중에 일괄적으로 HttpServletRequest를 @RequestHeader로 바꾸면 된다로 이해하면 좋을 것 같습니다.
