### PR TITLE
#50 Repository design refactoring

### DIFF
--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/comment/entity/v1/Comment.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/comment/entity/v1/Comment.kt
@@ -6,7 +6,6 @@ import org.hibernate.annotations.SQLDelete
 import org.hibernate.annotations.SQLRestriction
 import org.hibernate.annotations.UpdateTimestamp
 import jakarta.persistence.Table
-import org.hibernate.annotations.*
 import sparta.nbcamp.gamenomeprojectserver.domain.comment.dto.v1.CreateCommentRequestDto
 import sparta.nbcamp.gamenomeprojectserver.domain.review.model.v1.Review
 import sparta.nbcamp.gamenomeprojectserver.domain.user.model.User
@@ -46,8 +45,8 @@ class Comment private constructor(
     @Column(name = "deleted_at", nullable = true)
     val deletedAt: LocalDateTime? = null
 
-    fun update(comment: String) {
-        this.content = comment
+    fun updateContent(content: String) {
+        this.content = content
 
         this.validate()
     }

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/comment/repository/v1/CommentJpaRepository.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/comment/repository/v1/CommentJpaRepository.kt
@@ -2,13 +2,13 @@ package sparta.nbcamp.gamenomeprojectserver.domain.comment.repository.v1
 
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
 import sparta.nbcamp.gamenomeprojectserver.domain.comment.entity.v1.Comment
 
-interface CommentRepository {
+interface CommentJpaRepository: JpaRepository<Comment, Long> {
+
     fun findAllByReviewId(reviewId: Long, pageable: Pageable = Pageable.unpaged()): Page<Comment>
-    fun findByIdAndReviewId(commentId: Long, reviewId: Long): Comment?
-    fun find(commentId: Long): Comment?
-    fun exists(commentId: Long): Boolean
-    fun save(comment: Comment): Comment
-    fun delete(comment: Comment)
+
+    fun findByIdAndReviewId(reviewId: Long, commentId: Long): Comment
+
 }

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/comment/repository/v1/CommentJpaRepository.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/comment/repository/v1/CommentJpaRepository.kt
@@ -3,7 +3,7 @@ package sparta.nbcamp.gamenomeprojectserver.domain.comment.repository.v1
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
-import sparta.nbcamp.gamenomeprojectserver.domain.comment.entity.v1.Comment
+import sparta.nbcamp.gamenomeprojectserver.domain.comment.model.v1.Comment
 
 interface CommentJpaRepository: JpaRepository<Comment, Long> {
 

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/comment/repository/v1/CommentJpaRepository.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/comment/repository/v1/CommentJpaRepository.kt
@@ -11,4 +11,5 @@ interface CommentJpaRepository: JpaRepository<Comment, Long> {
 
     fun findByIdAndReviewId(reviewId: Long, commentId: Long): Comment
 
+    fun deleteByIdAndReviewId(commentId: Long, reviewId: Long)
 }

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/comment/repository/v1/CommentRepository.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/comment/repository/v1/CommentRepository.kt
@@ -11,4 +11,5 @@ interface CommentRepository {
     fun exists(commentId: Long): Boolean
     fun save(comment: Comment): Comment
     fun delete(comment: Comment)
+    fun deleteByIdAndReviewId(commentId: Long, reviewId: Long)
 }

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/comment/repository/v1/CommentRepositoryImpl.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/comment/repository/v1/CommentRepositoryImpl.kt
@@ -4,7 +4,7 @@ import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Repository
-import sparta.nbcamp.gamenomeprojectserver.domain.comment.entity.v1.Comment
+import sparta.nbcamp.gamenomeprojectserver.domain.comment.model.v1.Comment
 
 @Repository
 class CommentRepositoryImpl(

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/comment/repository/v1/CommentRepositoryImpl.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/comment/repository/v1/CommentRepositoryImpl.kt
@@ -1,0 +1,36 @@
+package sparta.nbcamp.gamenomeprojectserver.domain.comment.repository.v1
+
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+import sparta.nbcamp.gamenomeprojectserver.domain.comment.entity.v1.Comment
+
+@Repository
+class CommentRepositoryImpl(
+    val commentJpaRepository: CommentJpaRepository
+) : CommentRepository {
+    override fun findAllByReviewId(reviewId: Long, pageable: Pageable): Page<Comment> {
+        return commentJpaRepository.findAllByReviewId(reviewId, pageable)
+    }
+
+    override fun findByIdAndReviewId(commentId: Long, reviewId: Long): Comment? {
+        return commentJpaRepository.findByIdAndReviewId(reviewId, commentId)
+    }
+
+    override fun find(commentId: Long): Comment? {
+        return commentJpaRepository.findByIdOrNull(commentId)
+    }
+
+    override fun exists(commentId: Long): Boolean {
+        return commentJpaRepository.existsById(commentId)
+    }
+
+    override fun save(comment: Comment): Comment {
+        return commentJpaRepository.save(comment)
+    }
+
+    override fun delete(comment: Comment) {
+        commentJpaRepository.delete(comment)
+    }
+}

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/comment/repository/v1/CommentRepositoryImpl.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/comment/repository/v1/CommentRepositoryImpl.kt
@@ -33,4 +33,8 @@ class CommentRepositoryImpl(
     override fun delete(comment: Comment) {
         commentJpaRepository.delete(comment)
     }
+
+    override fun deleteByIdAndReviewId(commentId: Long, reviewId: Long) {
+        commentJpaRepository.deleteByIdAndReviewId(commentId, reviewId)
+    }
 }

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/comment/service/v1/CommentService.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/comment/service/v1/CommentService.kt
@@ -14,16 +14,17 @@ import sparta.nbcamp.gamenomeprojectserver.domain.report.entity.v1.EntityType
 import sparta.nbcamp.gamenomeprojectserver.domain.report.service.ReportService
 import sparta.nbcamp.gamenomeprojectserver.domain.review.repository.v1.ReviewRepository
 import sparta.nbcamp.gamenomeprojectserver.domain.security.service.AuthService
-import sparta.nbcamp.gamenomeprojectserver.domain.user.repository.UserJpaRepository
+import sparta.nbcamp.gamenomeprojectserver.domain.user.repository.UserRepository
 import sparta.nbcamp.gamenomeprojectserver.exception.ModelNotFoundException
 
 @Service
 class CommentService(
     private val commentRepository: CommentRepository,
     private val reviewRepository: ReviewRepository,
+    private val userRepository: UserRepository,
+
     private val authService: AuthService,
     private val reactionService: ReactionService,
-    private val userRepository: UserRepository,
     private val reportService: ReportService,
 ) {
 
@@ -32,7 +33,7 @@ class CommentService(
 
         val user = authService.getUserIdFromToken(token)
 
-        val userResult = userRepository.findByIdOrNull(user)?: throw ModelNotFoundException("User", user)
+        val userResult = userRepository.find(user)?: throw ModelNotFoundException("User", user)
 
         val reviewResult = reviewRepository.findByIdOrNull(reviewId)?: throw ModelNotFoundException("review", reviewId )
 
@@ -84,7 +85,7 @@ class CommentService(
     ): CommentReportResponseDto {
 
         val comment = commentRepository.findByIdAndReviewId(reviewId, commentId)
-        val user = userRepository.findByIdOrNull(reportCommentRequestDto.userId) ?: throw ModelNotFoundException(
+        val user = userRepository.find(reportCommentRequestDto.userId) ?: throw ModelNotFoundException(
             "User",
             reportCommentRequestDto.userId
         )
@@ -99,7 +100,7 @@ class CommentService(
         if(!reviewRepository.existsById(reviewId)) throw ModelNotFoundException("review", reviewId )
 
         val commentResult = commentRepository.findByIdOrNull(commentId)?: throw ModelNotFoundException("comment", commentId )
-        val userId = userService.getUserIdFromToken(token)
+        val userId = authService.getUserIdFromToken(token)
 
         reactionService.update(commentResult, ReactionType.Like, userId)
     }
@@ -108,7 +109,7 @@ class CommentService(
         if(!reviewRepository.existsById(reviewId)) throw ModelNotFoundException("review", reviewId )
 
         val commentResult = commentRepository.findByIdOrNull(commentId)?: throw ModelNotFoundException("comment", commentId )
-        val userId = userService.getUserIdFromToken(token)
+        val userId = authService.getUserIdFromToken(token)
 
         reactionService.update(commentResult, ReactionType.DisLike, userId)
     }

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/comment/service/v1/CommentService.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/comment/service/v1/CommentService.kt
@@ -12,7 +12,7 @@ import sparta.nbcamp.gamenomeprojectserver.domain.reaction.entity.v1.ReactionTyp
 import sparta.nbcamp.gamenomeprojectserver.domain.reaction.service.v1.ReactionService
 import sparta.nbcamp.gamenomeprojectserver.domain.report.entity.v1.EntityType
 import sparta.nbcamp.gamenomeprojectserver.domain.report.service.ReportService
-import sparta.nbcamp.gamenomeprojectserver.domain.review.repository.v1.ReviewRepository
+import sparta.nbcamp.gamenomeprojectserver.domain.review.repository.v1.ReviewJpaRepository
 import sparta.nbcamp.gamenomeprojectserver.domain.security.service.AuthService
 import sparta.nbcamp.gamenomeprojectserver.domain.user.repository.UserRepository
 import sparta.nbcamp.gamenomeprojectserver.exception.ModelNotFoundException
@@ -20,7 +20,7 @@ import sparta.nbcamp.gamenomeprojectserver.exception.ModelNotFoundException
 @Service
 class CommentService(
     private val commentRepository: CommentRepository,
-    private val reviewRepository: ReviewRepository,
+    private val reviewRepository: ReviewJpaRepository,
     private val userRepository: UserRepository,
 
     private val authService: AuthService,

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/comment/service/v1/CommentService.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/comment/service/v1/CommentService.kt
@@ -13,15 +13,15 @@ import sparta.nbcamp.gamenomeprojectserver.domain.reaction.service.v1.ReactionSe
 import sparta.nbcamp.gamenomeprojectserver.domain.report.entity.v1.EntityType
 import sparta.nbcamp.gamenomeprojectserver.domain.report.service.ReportService
 import sparta.nbcamp.gamenomeprojectserver.domain.review.repository.v1.ReviewRepository
-import sparta.nbcamp.gamenomeprojectserver.domain.user.repository.UserRepository
-import sparta.nbcamp.gamenomeprojectserver.domain.user.service.v1.UserService
+import sparta.nbcamp.gamenomeprojectserver.domain.security.service.AuthService
+import sparta.nbcamp.gamenomeprojectserver.domain.user.repository.UserJpaRepository
 import sparta.nbcamp.gamenomeprojectserver.exception.ModelNotFoundException
 
 @Service
 class CommentService(
     private val commentRepository: CommentRepository,
     private val reviewRepository: ReviewRepository,
-    private val userService: UserService,
+    private val authService: AuthService,
     private val reactionService: ReactionService,
     private val userRepository: UserRepository,
     private val reportService: ReportService,
@@ -30,7 +30,7 @@ class CommentService(
     @Transactional
     fun createComment(reviewId: Long, createCommentRequestDto: CreateCommentRequestDto, token:String): CommentResponseDto {
 
-        val user = userService.getUserIdFromToken(token)
+        val user = authService.getUserIdFromToken(token)
 
         val userResult = userRepository.findByIdOrNull(user)?: throw ModelNotFoundException("User", user)
 

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/follow/repository/v1/FollowJpaRepository.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/follow/repository/v1/FollowJpaRepository.kt
@@ -1,13 +1,11 @@
 package sparta.nbcamp.gamenomeprojectserver.domain.follow.repository.v1
 
+import org.springframework.data.jpa.repository.JpaRepository
 import sparta.nbcamp.gamenomeprojectserver.domain.follow.model.v1.Follow
 
-interface FollowRepository {
+
+interface FollowJpaRepository: JpaRepository<Follow, Long> {
     fun findByFollowingUserId(followingUserId: Long): Follow?
     fun findAllByUserId(userId: Long): List<Follow>
-    fun find(userId: Long): Follow?
-    fun deleteAllById(id: Long)
     fun deleteByUserIdAndFollowingUserId(userId: Long, followingUserId: Long)
-    fun delete(follow: Follow)
-    fun save(follow: Follow): Follow
 }

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/follow/repository/v1/FollowRepositoryImpl.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/follow/repository/v1/FollowRepositoryImpl.kt
@@ -1,0 +1,38 @@
+package sparta.nbcamp.gamenomeprojectserver.domain.follow.repository.v1
+
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+import sparta.nbcamp.gamenomeprojectserver.domain.follow.model.v1.Follow
+
+@Repository
+class FollowRepositoryImpl(
+    val followJpaRepository: FollowJpaRepository
+) : FollowRepository {
+    override fun findByFollowingUserId(followingUserId: Long): Follow? {
+        return followJpaRepository.findByFollowingUserId(followingUserId)
+    }
+
+    override fun findAllByUserId(userId: Long): List<Follow> {
+        return followJpaRepository.findAllByUserId(userId)
+    }
+
+    override fun find(userId: Long): Follow? {
+        return followJpaRepository.findByIdOrNull(userId)
+    }
+
+    override fun deleteAllById(id: Long) {
+        followJpaRepository.deleteById(id)
+    }
+
+    override fun deleteByUserIdAndFollowingUserId(userId: Long, followingUserId: Long) {
+        followJpaRepository.deleteByUserIdAndFollowingUserId(userId, followingUserId)
+    }
+
+    override fun delete(follow: Follow) {
+        followJpaRepository.delete(follow)
+    }
+
+    override fun save(follow: Follow): Follow {
+        return followJpaRepository.save(follow)
+    }
+}

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/follow/service/v1/FollowService.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/follow/service/v1/FollowService.kt
@@ -1,13 +1,12 @@
 package sparta.nbcamp.gamenomeprojectserver.domain.follow.service.v1
 
-import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import sparta.nbcamp.gamenomeprojectserver.domain.follow.dto.v1.FollowingRequestDto
 import sparta.nbcamp.gamenomeprojectserver.domain.follow.dto.v1.FollowingResponseDto
 import sparta.nbcamp.gamenomeprojectserver.domain.follow.model.v1.Follow
 import sparta.nbcamp.gamenomeprojectserver.domain.follow.repository.v1.FollowRepository
+import sparta.nbcamp.gamenomeprojectserver.domain.security.service.AuthService
 import sparta.nbcamp.gamenomeprojectserver.domain.user.repository.UserRepository
-import sparta.nbcamp.gamenomeprojectserver.domain.user.service.v1.UserService
 import sparta.nbcamp.gamenomeprojectserver.exception.DuplicatedException
 import sparta.nbcamp.gamenomeprojectserver.exception.ModelNotFoundException
 
@@ -15,13 +14,14 @@ import sparta.nbcamp.gamenomeprojectserver.exception.ModelNotFoundException
 @Service
 class FollowService(
     val followRepository: FollowRepository,
-    val userService: UserService,
-    val userRepository: UserRepository
+    val userRepository: UserRepository,
+
+    val authService: AuthService,
 ) {
     fun followUser(followingRequestDto: FollowingRequestDto, token: String) {
 
-        val userId = userService.getUserIdFromToken(token)
-        val user = userRepository.findByIdOrNull(userId) ?: throw ModelNotFoundException("User", userId)
+        val userId = authService.getUserIdFromToken(token)
+        val user = userRepository.find(userId) ?: throw ModelNotFoundException("User", userId)
         val follow = followRepository.findByFollowingUserId(followingRequestDto.followingUserId)
 
         if (follow != null) {
@@ -30,13 +30,13 @@ class FollowService(
             if (userId == followingRequestDto.followingUserId) {
                 throw DuplicatedException("본인은 팔로우 할 수 없습니다")
             }
-            val follower = Follow.from(followingRequestDto.followingUserId, user)
-            followRepository.save(follower)
+            val followe = Follow.from(followingRequestDto.followingUserId, user)
+            followRepository.save(followe)
         }
     }
 
     fun getFollowingUserList(token: String): FollowingResponseDto {
-        val userId = userService.getUserIdFromToken(token)
+        val userId = authService.getUserIdFromToken(token)
 
         val result = followRepository.findAllByUserId(userId)
 

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/reaction/repository/v1/ReactionJpaRepository.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/reaction/repository/v1/ReactionJpaRepository.kt
@@ -1,0 +1,12 @@
+package sparta.nbcamp.gamenomeprojectserver.domain.reaction.repository.v1
+
+import org.springframework.data.jpa.repository.JpaRepository
+import sparta.nbcamp.gamenomeprojectserver.domain.reaction.entity.v1.Reaction
+import sparta.nbcamp.gamenomeprojectserver.domain.reaction.entity.v1.ReactionType
+
+interface ReactionJpaRepository: JpaRepository<Reaction, Long> {
+
+    fun findByCommentIdAndReaction(commentId: Long, reaction: ReactionType):Reaction?
+
+    fun deleteAllByCommentId(commentId: Long)
+}

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/reaction/repository/v1/ReactionJpaRepository.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/reaction/repository/v1/ReactionJpaRepository.kt
@@ -1,8 +1,8 @@
 package sparta.nbcamp.gamenomeprojectserver.domain.reaction.repository.v1
 
 import org.springframework.data.jpa.repository.JpaRepository
-import sparta.nbcamp.gamenomeprojectserver.domain.reaction.entity.v1.Reaction
-import sparta.nbcamp.gamenomeprojectserver.domain.reaction.entity.v1.ReactionType
+import sparta.nbcamp.gamenomeprojectserver.domain.reaction.model.v1.Reaction
+import sparta.nbcamp.gamenomeprojectserver.domain.reaction.model.v1.ReactionType
 
 interface ReactionJpaRepository: JpaRepository<Reaction, Long> {
 

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/reaction/repository/v1/ReactionRepository.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/reaction/repository/v1/ReactionRepository.kt
@@ -1,10 +1,16 @@
 package sparta.nbcamp.gamenomeprojectserver.domain.reaction.repository.v1
 
-import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import sparta.nbcamp.gamenomeprojectserver.domain.reaction.entity.v1.Reaction
 import sparta.nbcamp.gamenomeprojectserver.domain.reaction.entity.v1.ReactionType
+import sparta.nbcamp.gamenomeprojectserver.domain.review.model.v1.Review
 
-interface ReactionRepository: JpaRepository<Reaction, Long> {
-
-    fun findByCommentIdAndReaction(commentId: Long, reaction: ReactionType):Reaction?
+interface ReactionRepository {
+    fun findAll(pageable: Pageable = Pageable.unpaged()): Page<Reaction>
+    fun findByCommentIdAndReaction(commentId: Long, reaction: ReactionType): Reaction?
+    fun save(reaction: Reaction): Reaction
+    fun delete(reaction: Reaction)
+    fun deleteById(reactionId: Long)
+    fun deleteAllByCommentId(commentId: Long)
 }

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/reaction/repository/v1/ReactionRepositoryImpl.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/reaction/repository/v1/ReactionRepositoryImpl.kt
@@ -3,8 +3,8 @@ package sparta.nbcamp.gamenomeprojectserver.domain.reaction.repository.v1
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Repository
-import sparta.nbcamp.gamenomeprojectserver.domain.reaction.entity.v1.Reaction
-import sparta.nbcamp.gamenomeprojectserver.domain.reaction.entity.v1.ReactionType
+import sparta.nbcamp.gamenomeprojectserver.domain.reaction.model.v1.Reaction
+import sparta.nbcamp.gamenomeprojectserver.domain.reaction.model.v1.ReactionType
 
 @Repository
 class ReactionRepositoryImpl(

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/reaction/repository/v1/ReactionRepositoryImpl.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/reaction/repository/v1/ReactionRepositoryImpl.kt
@@ -1,0 +1,36 @@
+package sparta.nbcamp.gamenomeprojectserver.domain.reaction.repository.v1
+
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Repository
+import sparta.nbcamp.gamenomeprojectserver.domain.reaction.entity.v1.Reaction
+import sparta.nbcamp.gamenomeprojectserver.domain.reaction.entity.v1.ReactionType
+
+@Repository
+class ReactionRepositoryImpl(
+    val reactionJpaRepository: ReactionJpaRepository
+) : ReactionRepository {
+    override fun findAll(pageable: Pageable): Page<Reaction> {
+        return reactionJpaRepository.findAll(pageable)
+    }
+
+    override fun findByCommentIdAndReaction(commentId: Long, reaction: ReactionType): Reaction? {
+        return reactionJpaRepository.findByCommentIdAndReaction(commentId, reaction)
+    }
+
+    override fun save(reaction: Reaction): Reaction {
+        return reactionJpaRepository.save(reaction)
+    }
+
+    override fun delete(reaction: Reaction) {
+        reactionJpaRepository.delete(reaction)
+    }
+
+    override fun deleteById(reactionId: Long) {
+        reactionJpaRepository.deleteById(reactionId)
+    }
+
+    override fun deleteAllByCommentId(commentId: Long) {
+        reactionJpaRepository.deleteAllByCommentId(commentId)
+    }
+}

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/reaction/service/v1/ReactionService.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/reaction/service/v1/ReactionService.kt
@@ -1,6 +1,5 @@
 package sparta.nbcamp.gamenomeprojectserver.domain.reaction.service.v1
 
-import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import sparta.nbcamp.gamenomeprojectserver.domain.comment.entity.v1.Comment
 import sparta.nbcamp.gamenomeprojectserver.domain.reaction.entity.v1.Reaction
@@ -15,10 +14,9 @@ class ReactionService(
     private val userRepository: UserRepository,
 ) {
 
-
     fun update(comment: Comment, reactionType: ReactionType, userId: Long){
         val result = reactionRepository.findByCommentIdAndReaction(comment.id!!, reactionType)
-        val user = userRepository.findByIdOrNull(userId)?: throw ModelNotFoundException("User", userId)
+        val user = userRepository.find(userId)?: throw ModelNotFoundException("User", userId)
         if (result == null) {
             reactionRepository.save(
                 Reaction(

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/reaction/service/v1/ReactionService.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/reaction/service/v1/ReactionService.kt
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service
 import sparta.nbcamp.gamenomeprojectserver.domain.comment.entity.v1.Comment
 import sparta.nbcamp.gamenomeprojectserver.domain.reaction.entity.v1.Reaction
 import sparta.nbcamp.gamenomeprojectserver.domain.reaction.entity.v1.ReactionType
+import sparta.nbcamp.gamenomeprojectserver.domain.reaction.repository.v1.ReactionJpaRepository
 import sparta.nbcamp.gamenomeprojectserver.domain.reaction.repository.v1.ReactionRepository
 import sparta.nbcamp.gamenomeprojectserver.domain.user.repository.UserRepository
 import sparta.nbcamp.gamenomeprojectserver.exception.ModelNotFoundException
@@ -14,9 +15,9 @@ class ReactionService(
     private val userRepository: UserRepository,
 ) {
 
-    fun update(comment: Comment, reactionType: ReactionType, userId: Long){
+    fun update(comment: Comment, reactionType: ReactionType, userId: Long) {
         val result = reactionRepository.findByCommentIdAndReaction(comment.id!!, reactionType)
-        val user = userRepository.find(userId)?: throw ModelNotFoundException("User", userId)
+        val user = userRepository.find(userId) ?: throw ModelNotFoundException("User", userId)
         if (result == null) {
             reactionRepository.save(
                 Reaction(
@@ -25,12 +26,12 @@ class ReactionService(
                     reaction = reactionType
                 )
             )
-        }else if(reactionType == result.reaction) reactionRepository.delete(result)
+        } else if (reactionType == result.reaction) reactionRepository.delete(result)
         else result.reaction = reactionType
     }
 
-    fun delete(comment: Comment,){
-        reactionRepository.deleteAllById(mutableListOf(comment.id))
+    fun delete(comment: Comment) {
+        reactionRepository.deleteAllByCommentId(comment.id!!)
     }
 
 }

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/report/repository/v1/ReportJpaRepository.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/report/repository/v1/ReportJpaRepository.kt
@@ -1,13 +1,13 @@
 package sparta.nbcamp.gamenomeprojectserver.domain.report.repository.v1
 
+import org.springframework.data.jpa.repository.JpaRepository
 import sparta.nbcamp.gamenomeprojectserver.domain.report.entity.v1.EntityType
 import sparta.nbcamp.gamenomeprojectserver.domain.report.entity.v1.Report
 
-interface ReportRepository {
-    fun findAll(): List<Report>
+interface ReportJpaRepository : JpaRepository<Report, Long> {
     fun findByEntityType(entityType: EntityType): List<Report>
+
     fun findByEntityId(entityId: Long): List<Report>
+
     fun findByUserId(userId: Long): List<Report>
-    fun save(report: Report): Report
-    fun deleteById(reportId: Long)
 }

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/report/repository/v1/ReportJpaRepository.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/report/repository/v1/ReportJpaRepository.kt
@@ -1,8 +1,8 @@
 package sparta.nbcamp.gamenomeprojectserver.domain.report.repository.v1
 
 import org.springframework.data.jpa.repository.JpaRepository
-import sparta.nbcamp.gamenomeprojectserver.domain.report.entity.v1.EntityType
-import sparta.nbcamp.gamenomeprojectserver.domain.report.entity.v1.Report
+import sparta.nbcamp.gamenomeprojectserver.domain.report.model.v1.EntityType
+import sparta.nbcamp.gamenomeprojectserver.domain.report.model.v1.Report
 
 interface ReportJpaRepository : JpaRepository<Report, Long> {
     fun findByEntityType(entityType: EntityType): List<Report>

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/report/repository/v1/ReportRepositoryImpl.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/report/repository/v1/ReportRepositoryImpl.kt
@@ -1,8 +1,8 @@
 package sparta.nbcamp.gamenomeprojectserver.domain.report.repository.v1
 
 import org.springframework.stereotype.Repository
-import sparta.nbcamp.gamenomeprojectserver.domain.report.entity.v1.EntityType
-import sparta.nbcamp.gamenomeprojectserver.domain.report.entity.v1.Report
+import sparta.nbcamp.gamenomeprojectserver.domain.report.model.v1.EntityType
+import sparta.nbcamp.gamenomeprojectserver.domain.report.model.v1.Report
 
 @Repository
 class ReportRepositoryImpl(

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/report/repository/v1/ReportRepositoryImpl.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/report/repository/v1/ReportRepositoryImpl.kt
@@ -1,0 +1,34 @@
+package sparta.nbcamp.gamenomeprojectserver.domain.report.repository.v1
+
+import org.springframework.stereotype.Repository
+import sparta.nbcamp.gamenomeprojectserver.domain.report.entity.v1.EntityType
+import sparta.nbcamp.gamenomeprojectserver.domain.report.entity.v1.Report
+
+@Repository
+class ReportRepositoryImpl(
+    private val reportJpaRepository: ReportJpaRepository
+) : ReportRepository {
+    override fun findAll(): List<Report> {
+        return reportJpaRepository.findAll()
+    }
+
+    override fun findByEntityType(entityType: EntityType): List<Report> {
+        return reportJpaRepository.findByEntityType(entityType)
+    }
+
+    override fun findByEntityId(entityId: Long): List<Report> {
+        return reportJpaRepository.findByEntityId(entityId)
+    }
+
+    override fun findByUserId(userId: Long): List<Report> {
+        return reportJpaRepository.findByUserId(userId)
+    }
+
+    override fun save(report: Report): Report {
+        return reportJpaRepository.save(report)
+    }
+
+    override fun deleteById(reportId: Long) {
+        return reportJpaRepository.deleteById(reportId)
+    }
+}

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/report/service/ReportService.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/report/service/ReportService.kt
@@ -5,6 +5,7 @@ import org.springframework.transaction.annotation.Transactional
 import sparta.nbcamp.gamenomeprojectserver.domain.comment.dto.v1.ReportCommentRequestDto
 import sparta.nbcamp.gamenomeprojectserver.domain.report.entity.v1.EntityType
 import sparta.nbcamp.gamenomeprojectserver.domain.report.entity.v1.Report
+import sparta.nbcamp.gamenomeprojectserver.domain.report.repository.v1.ReportJpaRepository
 import sparta.nbcamp.gamenomeprojectserver.domain.report.repository.v1.ReportRepository
 import sparta.nbcamp.gamenomeprojectserver.domain.review.dto.v1.ReviewReportDto
 import sparta.nbcamp.gamenomeprojectserver.domain.user.model.User

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/review/repository/v1/ReviewJpaRepository.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/review/repository/v1/ReviewJpaRepository.kt
@@ -1,0 +1,8 @@
+package sparta.nbcamp.gamenomeprojectserver.domain.review.repository.v1
+
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import sparta.nbcamp.gamenomeprojectserver.domain.review.model.v1.Review
+
+interface ReviewJpaRepository : JpaRepository<Review, Long>

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/review/repository/v1/ReviewRepository.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/review/repository/v1/ReviewRepository.kt
@@ -2,10 +2,14 @@ package sparta.nbcamp.gamenomeprojectserver.domain.review.repository.v1
 
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
-import org.springframework.data.jpa.repository.JpaRepository
 import sparta.nbcamp.gamenomeprojectserver.domain.review.model.v1.Review
 
-interface ReviewRepository : JpaRepository<Review, Long> {
-
-    fun findAllBy(pageable: Pageable = Pageable.unpaged()): Page<Review>
+interface ReviewRepository {
+    fun findAll(pageable: Pageable = Pageable.unpaged()): Page<Review>
+    fun findAllById(reviewIds: List<Long>): List<Review>
+    fun find(reviewId: Long): Review?
+    fun exists(reviewId: Long): Boolean
+    fun save(review: Review): Review
+    fun delete(review: Review)
+    fun deleteById(reviewId: Long)
 }

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/review/repository/v1/ReviewRepositoryImpl.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/review/repository/v1/ReviewRepositoryImpl.kt
@@ -1,0 +1,40 @@
+package sparta.nbcamp.gamenomeprojectserver.domain.review.repository.v1
+
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+import sparta.nbcamp.gamenomeprojectserver.domain.review.model.v1.Review
+
+@Repository
+class ReviewRepositoryImpl(
+    val reviewJpaRepository: ReviewJpaRepository
+) : ReviewRepository {
+    override fun findAll(pageable: Pageable): Page<Review> {
+        return reviewJpaRepository.findAll(pageable)
+    }
+
+    override fun findAllById(reviewIds: List<Long>): List<Review> {
+        return reviewJpaRepository.findAllById(reviewIds)
+    }
+
+    override fun find(reviewId: Long): Review? {
+        return reviewJpaRepository.findByIdOrNull(reviewId)
+    }
+
+    override fun exists(reviewId: Long): Boolean {
+        return reviewJpaRepository.existsById(reviewId)
+    }
+
+    override fun save(review: Review): Review {
+        return reviewJpaRepository.save(review)
+    }
+
+    override fun delete(review: Review) {
+        reviewJpaRepository.delete(review)
+    }
+
+    override fun deleteById(reviewId: Long) {
+        reviewJpaRepository.deleteById(reviewId)
+    }
+}

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/review/service/v1/ReviewServiceImpl.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/review/service/v1/ReviewServiceImpl.kt
@@ -30,29 +30,30 @@ class ReviewServiceImpl(
     }
 
     override fun getReviewPage(pageable: Pageable): Page<ReviewDto> {
-        val foundAllReview = reviewRepository.findAllBy(pageable)
+        val foundAllReview = reviewRepository.findAll(pageable)
         return foundAllReview.map { ReviewDto.from(it) }
     }
 
     @Transactional
     override fun updateReview(reviewId: Long, reviewUpdateDTO: ReviewUpdateDto): ReviewDto {
-        val foundReview = reviewRepository.findByIdOrNull(reviewId) ?: throw ModelNotFoundException("Review", reviewId)
+        val foundReview = reviewRepository.find(reviewId) ?: throw ModelNotFoundException("Review", reviewId)
         foundReview.updateReviewField(reviewUpdateDTO)
         return ReviewDto.from(foundReview)
     }
 
+    @Transactional
     override fun deleteReview(reviewId: Long) {
         reviewRepository.deleteById(reviewId)
     }
 
     override fun getReview(reviewId: Long): ReviewDto {
-        val foundReview = reviewRepository.findByIdOrNull(reviewId) ?: throw ModelNotFoundException("Review", reviewId)
+        val foundReview = reviewRepository.find(reviewId) ?: throw ModelNotFoundException("Review", reviewId)
         return ReviewDto.from(foundReview)
     }
 
     @Transactional
     override fun reportReview(reviewId: Long, reviewReportDTO: ReviewReportDto): ReviewDto {
-        val foundReview = reviewRepository.findByIdOrNull(reviewId) ?: throw ModelNotFoundException("Review", reviewId)
+        val foundReview = reviewRepository.find(reviewId) ?: throw ModelNotFoundException("Review", reviewId)
         val user = userRepository.find(reviewReportDTO.userId) ?: throw ModelNotFoundException(
             "User",
             reviewReportDTO.userId

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/review/service/v1/ReviewServiceImpl.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/review/service/v1/ReviewServiceImpl.kt
@@ -19,8 +19,9 @@ import sparta.nbcamp.gamenomeprojectserver.exception.ModelNotFoundException
 @Service
 class ReviewServiceImpl(
     private val reviewRepository: ReviewRepository,
+    private val userRepository: UserRepository,
+
     private val reportService: ReportService,
-    private val userRepository: UserRepository
 ) : ReviewService {
     @Transactional
     override fun createReview(reviewCreateDTO: ReviewCreateDto): ReviewDto {
@@ -52,7 +53,7 @@ class ReviewServiceImpl(
     @Transactional
     override fun reportReview(reviewId: Long, reviewReportDTO: ReviewReportDto): ReviewDto {
         val foundReview = reviewRepository.findByIdOrNull(reviewId) ?: throw ModelNotFoundException("Review", reviewId)
-        val user = userRepository.findByIdOrNull(reviewReportDTO.userId) ?: throw ModelNotFoundException(
+        val user = userRepository.find(reviewReportDTO.userId) ?: throw ModelNotFoundException(
             "User",
             reviewReportDTO.userId
         )

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/security/SecurityConfig.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/security/SecurityConfig.kt
@@ -1,4 +1,4 @@
-package sparta.nbcamp.gamenomeprojectserver.domain.security.jwt
+package sparta.nbcamp.gamenomeprojectserver.domain.security
 
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/security/service/AuthService.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/security/service/AuthService.kt
@@ -1,0 +1,7 @@
+package sparta.nbcamp.gamenomeprojectserver.domain.security.service
+
+interface AuthService {
+    fun generateToken(userId: Long): String
+    fun isValidToken(token: String): Boolean
+    fun getUserIdFromToken(token: String): Long
+}

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/security/service/AuthServiceImpl.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/security/service/AuthServiceImpl.kt
@@ -1,0 +1,21 @@
+package sparta.nbcamp.gamenomeprojectserver.domain.security.service
+
+import org.springframework.stereotype.Service
+import sparta.nbcamp.gamenomeprojectserver.domain.security.jwt.JwtPlugin
+
+@Service
+class AuthServiceImpl(
+    val jwtPlugin: JwtPlugin
+): AuthService {
+    override fun generateToken(userId: Long): String {
+        return jwtPlugin.generateAccessToken("userId", userId)
+    }
+
+    override fun isValidToken(token: String): Boolean {
+        return jwtPlugin.validateToken(token).isSuccess
+    }
+
+    override fun getUserIdFromToken(token: String): Long {
+        return (jwtPlugin.validateToken(token).getOrNull()?.payload?.get("userId") as Int).toLong()
+    }
+}

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/controller/v1/UserController.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/controller/v1/UserController.kt
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import sparta.nbcamp.gamenomeprojectserver.domain.security.jwt.JwtResponseDto
+import sparta.nbcamp.gamenomeprojectserver.domain.security.service.AuthService
 import sparta.nbcamp.gamenomeprojectserver.domain.user.dto.SignInDto
 import sparta.nbcamp.gamenomeprojectserver.domain.user.dto.SignUpDto
 import sparta.nbcamp.gamenomeprojectserver.domain.user.dto.UserDto
@@ -14,7 +15,8 @@ import sparta.nbcamp.gamenomeprojectserver.domain.user.service.v1.UserService
 @RequestMapping("api/v1")
 @RestController
 class UserController(
-    val userService: UserService
+    val userService: UserService,
+    val authService: AuthService
 ){
     @PostMapping("/signup")
     fun signUp(@RequestBody request: SignUpDto): ResponseEntity<UserDto> {
@@ -57,6 +59,6 @@ class UserController(
         request: HttpServletRequest
     ): ResponseEntity<Long> {
         val authorization = request.getHeader("Authorization") ?: return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
-        return ResponseEntity.status(HttpStatus.OK).body(userService.getUserIdFromToken(authorization))
+        return ResponseEntity.status(HttpStatus.OK).body(authService.getUserIdFromToken(authorization))
     }
 }

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/repository/UserJpaRepository.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/repository/UserJpaRepository.kt
@@ -4,5 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 import sparta.nbcamp.gamenomeprojectserver.domain.user.model.User
 
 interface UserJpaRepository : JpaRepository<User, Long> {
+    fun findByProfileNickname(nickname: String): User?
     fun findByEmail(email: String): User?
 }

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/repository/UserJpaRepository.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/repository/UserJpaRepository.kt
@@ -1,11 +1,8 @@
 package sparta.nbcamp.gamenomeprojectserver.domain.user.repository
 
+import org.springframework.data.jpa.repository.JpaRepository
 import sparta.nbcamp.gamenomeprojectserver.domain.user.model.User
 
-interface UserRepository {
+interface UserJpaRepository : JpaRepository<User, Long> {
     fun findByEmail(email: String): User?
-    fun find(userId: Long): User?
-    fun exists(userId: Long): Boolean
-    fun save(user: User): User
-    fun delete(user: User)
 }

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/repository/UserRepository.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/repository/UserRepository.kt
@@ -3,6 +3,7 @@ package sparta.nbcamp.gamenomeprojectserver.domain.user.repository
 import sparta.nbcamp.gamenomeprojectserver.domain.user.model.User
 
 interface UserRepository {
+    fun findAllById(ids: List<Long>): List<User>
     fun findByProfileNickname(nickname: String): User?
     fun findByEmail(email: String): User?
     fun find(userId: Long): User?

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/repository/UserRepositoryImpl.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/repository/UserRepositoryImpl.kt
@@ -8,6 +8,13 @@ import sparta.nbcamp.gamenomeprojectserver.domain.user.model.User
 class UserRepositoryImpl(
     private val userJpaRepository: UserJpaRepository
 ) : UserRepository {
+    override fun findAllById(ids: List<Long>): List<User> {
+        return userJpaRepository.findAllById(ids)
+    }
+
+    override fun findByProfileNickname(nickname: String): User? {
+        return userJpaRepository.findByProfileNickname(nickname)
+    }
 
     override fun findByEmail(email: String): User? {
         return userJpaRepository.findByEmail(email)

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/repository/UserRepositoryImpl.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/repository/UserRepositoryImpl.kt
@@ -1,0 +1,31 @@
+package sparta.nbcamp.gamenomeprojectserver.domain.user.repository
+
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+import sparta.nbcamp.gamenomeprojectserver.domain.user.model.User
+
+@Repository
+class UserRepositoryImpl(
+    private val userJpaRepository: UserJpaRepository
+) : UserRepository {
+
+    override fun findByEmail(email: String): User? {
+        return userJpaRepository.findByEmail(email)
+    }
+
+    override fun find(userId: Long): User? {
+        return userJpaRepository.findByIdOrNull(userId)
+    }
+
+    override fun exists(userId: Long): Boolean {
+        return userJpaRepository.existsById(userId)
+    }
+
+    override fun save(user: User): User {
+        return userJpaRepository.save(user)
+    }
+
+    override fun delete(user: User) {
+        userJpaRepository.delete(user)
+    }
+}

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/service/v1/UserService.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/service/v1/UserService.kt
@@ -13,6 +13,4 @@ interface UserService {
     fun getUserProfileList(userIds: List<Long>): List<UserDto>
     fun updateProfile(userId: Long, request: UserUpdateProfileDto): UserDto
     fun deactivateUser(userId: Long)
-    fun isValidToken(token: String): Boolean
-    fun getUserIdFromToken(token: String): Long
 }

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/service/v1/UserService.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/service/v1/UserService.kt
@@ -10,7 +10,6 @@ interface UserService {
     fun signUp(request: SignUpDto): UserDto
     fun signIn(request: SignInDto): JwtResponseDto
     fun getUserProfile(userId: Long): UserDto
-    fun getUserProfileList(userIds: List<Long>): List<UserDto>
     fun updateProfile(userId: Long, request: UserUpdateProfileDto): UserDto
     fun deactivateUser(userId: Long)
 }

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/service/v1/UserServiceImpl.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/service/v1/UserServiceImpl.kt
@@ -1,6 +1,5 @@
 package sparta.nbcamp.gamenomeprojectserver.domain.user.service.v1
 
-import org.springframework.data.repository.findByIdOrNull
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -47,20 +46,15 @@ class UserServiceImpl(
     }
 
     override fun getUserProfile(userId: Long): UserDto {
-        val user = userRepository.findByIdOrNull(userId) ?: throw ModelNotFoundException("User not found", userId)
+        val user = userRepository.find(userId) ?: throw ModelNotFoundException("User not found", userId)
 
         return UserDto.fromEntity(user)
     }
 
-    override fun getUserProfileList(userIds: List<Long>): List<UserDto> {
-        return userRepository.findAllById(userIds).map { UserDto.fromEntity(it) }
-    }
-
     @Transactional
     override fun updateProfile(userId: Long, request: UserUpdateProfileDto): UserDto {
-        val user = userRepository.findByIdOrNull(userId) ?: throw ModelNotFoundException("User not found", userId)
+        val user = userRepository.find(userId) ?: throw ModelNotFoundException("User not found", userId)
 
-//        if (!user.checkUpdatePermission())
         user.updateProfile(request)
 
         return UserDto.fromEntity(user)
@@ -68,7 +62,7 @@ class UserServiceImpl(
 
     @Transactional
     override fun deactivateUser(userId: Long) {
-        val user = userRepository.findByIdOrNull(userId) ?: throw ModelNotFoundException("User not found", userId)
+        val user = userRepository.find(userId) ?: throw ModelNotFoundException("User not found", userId)
 
         userRepository.delete(user)
     }

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/service/v1/UserServiceImpl.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/service/v1/UserServiceImpl.kt
@@ -3,14 +3,12 @@ package sparta.nbcamp.gamenomeprojectserver.domain.user.service.v1
 import jakarta.mail.Message
 import jakarta.mail.internet.InternetAddress
 import jakarta.mail.internet.MimeMessage
-import org.springframework.data.repository.findByIdOrNull
-import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.mail.javamail.JavaMailSender
+import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import sparta.nbcamp.gamenomeprojectserver.domain.common.utils.RedisUtils
 import sparta.nbcamp.gamenomeprojectserver.domain.common.utils.Secret
-import sparta.nbcamp.gamenomeprojectserver.domain.security.jwt.JwtPlugin
 import sparta.nbcamp.gamenomeprojectserver.domain.security.jwt.JwtResponseDto
 import sparta.nbcamp.gamenomeprojectserver.domain.security.service.AuthService
 import sparta.nbcamp.gamenomeprojectserver.domain.user.dto.*

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/service/v1/UserServiceImpl.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/service/v1/UserServiceImpl.kt
@@ -4,8 +4,8 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import sparta.nbcamp.gamenomeprojectserver.domain.security.jwt.JwtPlugin
 import sparta.nbcamp.gamenomeprojectserver.domain.security.jwt.JwtResponseDto
+import sparta.nbcamp.gamenomeprojectserver.domain.security.service.AuthService
 import sparta.nbcamp.gamenomeprojectserver.domain.user.dto.SignInDto
 import sparta.nbcamp.gamenomeprojectserver.domain.user.dto.SignUpDto
 import sparta.nbcamp.gamenomeprojectserver.domain.user.dto.UserDto
@@ -17,7 +17,7 @@ import sparta.nbcamp.gamenomeprojectserver.exception.ModelNotFoundException
 @Service
 class UserServiceImpl(
     val userRepository: UserRepository,
-    val jwtPlugin: JwtPlugin,
+    val authService: AuthService,
     val passwordEncoder: PasswordEncoder
 ) : UserService {
 
@@ -39,7 +39,7 @@ class UserServiceImpl(
 
         if (!passwordEncoder.matches(request.password, user.password)) throw IllegalStateException("Password is incorrect")
 
-        val accessToken = jwtPlugin.generateAccessToken("userId", user.id ?: throw RuntimeException("User id is invalid"))
+        val accessToken = authService.generateToken(user.id!!)
 
         user.signIn()
 

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/service/v1/UserServiceImpl.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/service/v1/UserServiceImpl.kt
@@ -72,12 +72,4 @@ class UserServiceImpl(
 
         userRepository.delete(user)
     }
-
-    override fun isValidToken(token: String): Boolean {
-        return jwtPlugin.validateToken(token).isSuccess
-    }
-
-    override fun getUserIdFromToken(token: String): Long {
-        return (jwtPlugin.validateToken(token).getOrNull()?.payload?.get("userId") as Int).toLong()
-    }
 }


### PR DESCRIPTION


서비스에서 직접적으로 JpaRepository를 참조하는 일이 없게 하고 Pojo interface인 Repository, 그리고 RepositoryImpl 을 구현해 접근 가능한 저장소의 영역을 제한했습니다.

겉보기엔 그냥 메소드 이름을 중복으로 작성한 거랑 똑같은데 JpaRepository가 상속받고 있는 CRUDRepository, SortingAndPagingRepository 같은 곳에서 제공하는 기본 메소드에 접근이 함부로 가능해져서 외부에서 접근 가능한 저장소 기능을 제한한다고 보면 됩니다.

요청의 흐름
Service -> Repository -> JpaRepository

저장소에 추가적으로 필요한 기능이 생기면 Repository에 새로 정의하고 RepositoryImpl 에서 해당하는 기능 JpaRepository 이용하면 됩니다.

그리고 이 PR에 Auth service로 분리한 내용과 사소한 bugfix가 포함되어 있습니다.