### PR TITLE
#27 이메일 인증 및 닉네임 중복 확인 기능

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,7 +32,8 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0")
     implementation("io.jsonwebtoken:jjwt:0.12.5")
-
+    implementation ("org.springframework.boot:spring-boot-starter-data-redis")
+    implementation ("org.springframework.boot:spring-boot-starter-mail")
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/common/utils/RedisUtils.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/common/utils/RedisUtils.kt
@@ -1,0 +1,27 @@
+package sparta.nbcamp.gamenomeprojectserver.domain.common.utils
+
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.stereotype.Component
+import java.time.Duration
+
+@Component
+class RedisUtils(
+    private val redisTemplate: RedisTemplate<String, String>,
+) {
+
+    private val DURATION_TIME = 1000 * 60 * 60 * 24L
+
+    fun getData(key: String): String? {
+        val valueOperations = redisTemplate.opsForValue()
+        return valueOperations[key]
+    }
+
+    fun setDataExpire(key: String, value: String) {
+        val valueOperations = redisTemplate.opsForValue()
+        valueOperations.set(key, value, Duration.ofMillis(DURATION_TIME))
+    }
+
+    fun deleteData(key: String) {
+        redisTemplate.delete(key)
+    }
+}

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/common/utils/Secret.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/common/utils/Secret.kt
@@ -1,0 +1,5 @@
+package sparta.nbcamp.gamenomeprojectserver.domain.common.utils
+
+object Secret {
+    const val RECIPIENT = "seongwoorang@naver.com"
+}

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/controller/v1/UserController.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/controller/v1/UserController.kt
@@ -4,17 +4,14 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import sparta.nbcamp.gamenomeprojectserver.domain.security.jwt.JwtResponseDto
-import sparta.nbcamp.gamenomeprojectserver.domain.user.dto.SignInDto
-import sparta.nbcamp.gamenomeprojectserver.domain.user.dto.SignUpDto
-import sparta.nbcamp.gamenomeprojectserver.domain.user.dto.UserDto
-import sparta.nbcamp.gamenomeprojectserver.domain.user.dto.UserUpdateProfileDto
+import sparta.nbcamp.gamenomeprojectserver.domain.user.dto.*
 import sparta.nbcamp.gamenomeprojectserver.domain.user.service.v1.UserService
 
 @RequestMapping("api/v1")
 @RestController
 class UserController(
     val userService: UserService
-){
+) {
     @PostMapping("/signup")
     fun signUp(@RequestBody request: SignUpDto): ResponseEntity<UserDto> {
         return ResponseEntity.status(HttpStatus.CREATED).body(userService.signUp(request))
@@ -59,5 +56,14 @@ class UserController(
     @GetMapping("/users/checkNickname")
     fun checkNicknameDuplicate(@RequestParam nickname: String): ResponseEntity<Boolean> {
         return ResponseEntity.status(HttpStatus.OK).body(userService.isNicknameDuplicate(nickname))
+    }
+
+    @PostMapping("/users/email")
+    fun sendMail(
+        @RequestParam email: String
+    ): ResponseEntity<SendMailResponse> {
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(userService.sendMail(email))
     }
 }

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/controller/v1/UserController.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/controller/v1/UserController.kt
@@ -66,4 +66,14 @@ class UserController(
             .status(HttpStatus.OK)
             .body(userService.sendMail(email))
     }
+
+    @PostMapping("/users/email/check")
+    fun checkCertification(
+        @RequestParam email: String,
+        @RequestParam code: String
+    ): ResponseEntity<SendMailResponse> {
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(userService.checkCertification(email, code))
+    }
 }

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/controller/v1/UserController.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/controller/v1/UserController.kt
@@ -55,4 +55,9 @@ class UserController(
     fun checkUserId(@RequestParam token: String): ResponseEntity<Long> {
         return ResponseEntity.status(HttpStatus.OK).body(userService.getUserIdFromToken(token))
     }
+
+    @GetMapping("/users/checkNickname")
+    fun checkNicknameDuplicate(@RequestParam nickname: String): ResponseEntity<Boolean> {
+        return ResponseEntity.status(HttpStatus.OK).body(userService.isNicknameDuplicate(nickname))
+    }
 }

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/dto/SendMailResponse.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/dto/SendMailResponse.kt
@@ -1,0 +1,5 @@
+package sparta.nbcamp.gamenomeprojectserver.domain.user.dto
+
+data class SendMailResponse(
+    val message: String
+)

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/repository/UserRepository.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/repository/UserRepository.kt
@@ -5,4 +5,5 @@ import sparta.nbcamp.gamenomeprojectserver.domain.user.model.User
 
 interface UserRepository : JpaRepository<User, Long> {
     fun findByEmail(email: String): User?
+    fun findByProfileNickname(nickname: String): User?
 }

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/service/v1/UserService.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/service/v1/UserService.kt
@@ -14,4 +14,5 @@ interface UserService {
     fun getUserIdFromToken(token: String): Long
     fun isNicknameDuplicate(nickname: String): Boolean
     fun sendMail(email : String): SendMailResponse
+    fun checkCertification(email: String, code: String): SendMailResponse
 }

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/service/v1/UserService.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/service/v1/UserService.kt
@@ -1,10 +1,7 @@
 package sparta.nbcamp.gamenomeprojectserver.domain.user.service.v1
 
 import sparta.nbcamp.gamenomeprojectserver.domain.security.jwt.JwtResponseDto
-import sparta.nbcamp.gamenomeprojectserver.domain.user.dto.SignInDto
-import sparta.nbcamp.gamenomeprojectserver.domain.user.dto.SignUpDto
-import sparta.nbcamp.gamenomeprojectserver.domain.user.dto.UserDto
-import sparta.nbcamp.gamenomeprojectserver.domain.user.dto.UserUpdateProfileDto
+import sparta.nbcamp.gamenomeprojectserver.domain.user.dto.*
 
 interface UserService {
     fun signUp(request: SignUpDto): UserDto
@@ -16,4 +13,5 @@ interface UserService {
     fun isValidToken(token: String): Boolean
     fun getUserIdFromToken(token: String): Long
     fun isNicknameDuplicate(nickname: String): Boolean
+    fun sendMail(email : String): SendMailResponse
 }

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/service/v1/UserService.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/service/v1/UserService.kt
@@ -15,4 +15,5 @@ interface UserService {
     fun deactivateUser(userId: Long)
     fun isValidToken(token: String): Boolean
     fun getUserIdFromToken(token: String): Long
+    fun isNicknameDuplicate(nickname: String): Boolean
 }

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/service/v1/UserServiceImpl.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/service/v1/UserServiceImpl.kt
@@ -78,4 +78,8 @@ class UserServiceImpl(
     override fun getUserIdFromToken(token: String): Long {
         return (jwtPlugin.validateToken(token).getOrNull()?.payload?.get("userId") as Int).toLong()
     }
+
+    override fun isNicknameDuplicate(nickname: String): Boolean {
+        return userRepository.findByProfileNickname(nickname) != null
+    }
 }

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/infra/redis/RedisConfig.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/infra/redis/RedisConfig.kt
@@ -1,0 +1,48 @@
+package sparta.nbcamp.gamenomeprojectserver.infra.redis
+
+import org.springframework.cache.CacheManager
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.cache.RedisCacheConfiguration
+import org.springframework.data.redis.cache.RedisCacheManager
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.serializer.StringRedisSerializer
+import java.time.Duration
+
+@Configuration
+@EnableCaching
+class RedisConfig {
+    @Bean
+    fun lettuceConnectionFactory(): LettuceConnectionFactory {
+        val redisStandaloneConfiguration = RedisStandaloneConfiguration("localhost", 6379)
+
+        val lettuceClientConfiguration = LettuceClientConfiguration.builder()
+            .commandTimeout(Duration.ofSeconds(10))
+            .shutdownTimeout(Duration.ofMillis(100))
+            .build()
+
+        return LettuceConnectionFactory(redisStandaloneConfiguration, lettuceClientConfiguration)
+    }
+
+    @Bean
+    fun redisTemplate(): RedisTemplate<String, String> {
+        val template = RedisTemplate<String, String>()
+        template.keySerializer = StringRedisSerializer()
+        template.valueSerializer = StringRedisSerializer()
+        template.setConnectionFactory(lettuceConnectionFactory())
+        return template
+    }
+
+    @Bean
+    fun cacheManager(): CacheManager {
+        val redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+            .entryTtl(Duration.ofMinutes(1))
+        return RedisCacheManager.builder(lettuceConnectionFactory())
+            .cacheDefaults(redisCacheConfiguration)
+            .build()
+    }
+}


### PR DESCRIPTION
* 이메일 인증 시 네이버 smtp 사용하여 진행하였습니다.
* redis 사용하여 이메일 인증 시 사용자에게 전송한 코드를 이메일을 키로 하여 저장합니다.
* 전송 코드 체크 api에서 사용자가 받은 인증코드와 저장되어 있는 코드를 비교합니다.
