### PR TITLE
#63 회원 탈퇴 token 기반 진행과 password 2번 받기

### DIFF
--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/controller/v1/UserController.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/controller/v1/UserController.kt
@@ -14,7 +14,7 @@ import sparta.nbcamp.gamenomeprojectserver.domain.user.service.v1.UserService
 class UserController(
     val userService: UserService,
     val authService: AuthService
-){
+) {
     @PostMapping("/signup")
     fun signUp(@RequestBody request: SignUpDto): ResponseEntity<UserDto> {
         return ResponseEntity.status(HttpStatus.CREATED).body(userService.signUp(request))
@@ -27,7 +27,7 @@ class UserController(
 
     @PostMapping("/signout")
     fun signOut(): ResponseEntity<Unit> {
-        // TODO: signOut Logic (세션은 Service 안가고 Controller에서 바로 끊었는데 JWT는 아직 불확실함)
+        // TODO: 로그아웃 로직에 대해서는 이슈 #82 참고
 
         return ResponseEntity.status(HttpStatus.OK).build()
     }
@@ -46,16 +46,18 @@ class UserController(
     }
 
     @DeleteMapping("/users/deactivate")
-    fun deactivateUser(): ResponseEntity<Unit> {
-        TODO()
-//        return ResponseEntity.status(HttpStatus.NO_CONTENT).body(userService.deactivateUser(userId))
+    fun deactivateUser(request: HttpServletRequest): ResponseEntity<Unit> {
+        val authorization =
+            request.getHeader("Authorization") ?: return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).body(userService.deactivateUser(authorization))
     }
 
     @GetMapping("/token/checkUserId")
     fun checkUserId(
         request: HttpServletRequest
     ): ResponseEntity<Long> {
-        val authorization = request.getHeader("Authorization") ?: return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
+        val authorization =
+            request.getHeader("Authorization") ?: return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
         return ResponseEntity.status(HttpStatus.OK).body(authService.getUserIdFromToken(authorization))
     }
 

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/controller/v1/UserController.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/controller/v1/UserController.kt
@@ -17,6 +17,8 @@ class UserController(
 ) {
     @PostMapping("/signup")
     fun signUp(@RequestBody request: SignUpDto): ResponseEntity<UserDto> {
+        if (request.password != request.confirmPassword) return ResponseEntity.status(HttpStatus.BAD_REQUEST).build()
+
         return ResponseEntity.status(HttpStatus.CREATED).body(userService.signUp(request))
     }
 
@@ -42,6 +44,8 @@ class UserController(
         @PathVariable("userId") userId: Long,
         @RequestBody request: UserUpdateProfileDto
     ): ResponseEntity<UserDto> {
+        if (request.password != request.confirmPassword) return ResponseEntity.status(HttpStatus.BAD_REQUEST).build()
+
         return ResponseEntity.status(HttpStatus.OK).body(userService.updateProfile(userId, request))
     }
 

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/dto/EmailPasswordValidatableDto.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/dto/EmailPasswordValidatableDto.kt
@@ -1,11 +1,14 @@
 package sparta.nbcamp.gamenomeprojectserver.domain.user.dto
 
+import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Size
 
 abstract class EmailPasswordValidatableDto(
+
     @field:NotBlank
     @field:Size(max = 50, message = "Email must be 50 characters or less")
+    @field:Email(message = "Email must be a valid email address")
     open val email: String,
 
     @field:NotBlank

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/dto/SignUpDto.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/dto/SignUpDto.kt
@@ -7,6 +7,8 @@ data class SignUpDto (
     override val email: String,
     override val password: String,
 
+    val confirmPassword: String,
+
     @field:NotBlank
     @field:Size(min = 2, max = 20, message = "Nickname must be between 2 and 20 characters")
     val nickname: String,

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/dto/UserUpdateProfileDto.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/dto/UserUpdateProfileDto.kt
@@ -7,6 +7,8 @@ data class UserUpdateProfileDto(
     override val email: String,
     override val password: String,
 
+    val confirmPassword: String,
+
     @field:NotBlank
     @field:Size(min = 2, max = 20, message = "Nickname must be between 2 and 20 characters")
     val nickname: String,

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/model/User.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/model/User.kt
@@ -38,8 +38,6 @@ class User private constructor(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long? = null
 
-
-
     fun updateProfile(request: UserUpdateProfileDto) {
         this.email = request.email
         this.password = request.password

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/repository/UserJpaRepository.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/repository/UserJpaRepository.kt
@@ -4,6 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 import sparta.nbcamp.gamenomeprojectserver.domain.user.model.User
 
 interface UserJpaRepository : JpaRepository<User, Long> {
-    fun findByProfileNickname(nickname: String): User?
     fun findByEmail(email: String): User?
+    fun existsByProfileNickname(nickname: String): Boolean
 }

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/repository/UserRepository.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/repository/UserRepository.kt
@@ -4,10 +4,10 @@ import sparta.nbcamp.gamenomeprojectserver.domain.user.model.User
 
 interface UserRepository {
     fun findAllById(ids: List<Long>): List<User>
-    fun findByProfileNickname(nickname: String): User?
     fun findByEmail(email: String): User?
     fun find(userId: Long): User?
     fun exists(userId: Long): Boolean
+    fun existsByNickname(nickname: String): Boolean
     fun save(user: User): User
     fun delete(user: User)
 }

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/repository/UserRepositoryImpl.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/repository/UserRepositoryImpl.kt
@@ -12,10 +12,6 @@ class UserRepositoryImpl(
         return userJpaRepository.findAllById(ids)
     }
 
-    override fun findByProfileNickname(nickname: String): User? {
-        return userJpaRepository.findByProfileNickname(nickname)
-    }
-
     override fun findByEmail(email: String): User? {
         return userJpaRepository.findByEmail(email)
     }
@@ -26,6 +22,10 @@ class UserRepositoryImpl(
 
     override fun exists(userId: Long): Boolean {
         return userJpaRepository.existsById(userId)
+    }
+
+    override fun existsByNickname(nickname: String): Boolean {
+        return userJpaRepository.existsByProfileNickname(nickname)
     }
 
     override fun save(user: User): User {

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/service/v1/UserService.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/service/v1/UserService.kt
@@ -8,7 +8,7 @@ interface UserService {
     fun signIn(request: SignInDto): JwtResponseDto
     fun getUserProfile(userId: Long): UserDto
     fun updateProfile(userId: Long, request: UserUpdateProfileDto): UserDto
-    fun deactivateUser(userId: Long)
+    fun deactivateUser(token: String)
     fun isNicknameDuplicate(nickname: String): Boolean
     fun sendMail(email : String): SendMailResponse
     fun checkCertification(email: String, code: String): SendMailResponse

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/service/v1/UserServiceImpl.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/service/v1/UserServiceImpl.kt
@@ -74,7 +74,7 @@ class UserServiceImpl(
     }
 
     override fun isNicknameDuplicate(nickname: String): Boolean {
-        return userRepository.findByProfileNickname(nickname) != null
+        return !userRepository.existsByNickname(nickname)
     }
 
     override fun sendMail(email: String): SendMailResponse {

--- a/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/service/v1/UserServiceImpl.kt
+++ b/src/main/kotlin/sparta/nbcamp/gamenomeprojectserver/domain/user/service/v1/UserServiceImpl.kt
@@ -67,7 +67,8 @@ class UserServiceImpl(
     }
 
     @Transactional
-    override fun deactivateUser(userId: Long) {
+    override fun deactivateUser(token: String) {
+        val userId = authService.getUserIdFromToken(token)
         val user = userRepository.find(userId) ?: throw ModelNotFoundException("User not found", userId)
 
         userRepository.delete(user)


### PR DESCRIPTION

단순히 회원 탈퇴 / 체크용 추가 password 받는 것만 진행했습니다


로그아웃 로직은 Refresh token이 없으면 단순 Access token으로 처리하기는 굉장히 까다로워서 이번 프로젝트에선 구현을 못할 것 같습니다.

지금은 프론트앤드가 저장한 토큰을 말소시키는 방식이 제일 쉬울 것 같습니다

관련 조사한 내용 #82 로그아웃 구현에 적어놨습니다